### PR TITLE
Health check improvements

### DIFF
--- a/app/dimmer/app/HealthActor.scala
+++ b/app/dimmer/app/HealthActor.scala
@@ -1,14 +1,16 @@
 package dimmer.app
 
+import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
 import akka.actor.Actor
+import akka.pattern.after
 import dimmer.app.HealthActor.{CheckHealth, GetHealth, HealthStatus}
 import slick.backend.DatabaseConfig
 import slick.driver.PostgresDriver
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 
 object HealthActor {
 
@@ -31,21 +33,17 @@ class HealthActor @Inject() (dbConfig: DatabaseConfig[PostgresDriver]) extends A
   override def postStop() = repeatedlyHealthCheck.cancel()
 
   def checkHealth(): Unit = {
+    import dbConfig.driver.api._
+    implicit val ec: ExecutionContext = context.system.dispatcher
 
-    val db = dbConfig.db
-    try {
-
-      import dbConfig.driver.api._
-
-      val sqlStatement = sql"""SELECT 1""".as[Int].head
-      val result: Int = Await.result(db.run(sqlStatement), 500.milliseconds)
-
-      databaseHealthy = result == 1
-    } catch {
-      case e: Exception => {
-        databaseHealthy = false
-      }
+    def timeout[T](future: Future[T]): Future[T] = {
+      val timeoutFuture = after(500.milliseconds, context.system.scheduler) { Future.failed(new TimeoutException()) }
+      Future.firstCompletedOf(List(future, timeoutFuture))
     }
+
+    timeout(dbConfig.db.run(sql"""SELECT 1""".as[Int].head))
+      .map(result => databaseHealthy = result == 1)
+      .recover { case _ => databaseHealthy = false }
   }
 
   override def receive = {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -97,7 +97,7 @@ slick {
     password = ${?POSTGRES_PASSWORD}
     driver = "org.postgresql.Driver"
     connectionTestQuery = "SELECT 1" // postgres doesnt support connection timeout
-    maxConnections = 5
+    maxConnections = 2
     minConnections = 1
   }
 }


### PR DESCRIPTION
- reducing connection pool size for health check to 2
- avoiding blocking in health check