### PR TITLE
Adding event publishing facility

### DIFF
--- a/app/dimmer/logging/EventPublisher.scala
+++ b/app/dimmer/logging/EventPublisher.scala
@@ -1,0 +1,38 @@
+package dimmer.logging
+
+import net.logstash.logback.marker.LogstashMarker
+import net.logstash.logback.marker.Markers.appendEntries
+import org.slf4j.{Logger, LoggerFactory}
+
+trait Event {
+
+  def eventName: String
+
+  def eventFields: Seq[(String, Any)]
+}
+
+trait EventPublishing {
+  val publisher = new EventPublisher
+}
+
+object EventPublisher {
+  val eventLogger: Logger = LoggerFactory.getLogger("event-logger")
+}
+
+class EventPublisher {
+  import EventPublisher._
+  import collection.JavaConverters._
+
+  def event(name: String, fields: (String, Any)*): Unit = eventLogger.info(markers(name, fields), "")
+
+  def event(name: String, exception: Throwable, fields: (String, Any)*): Unit = {
+    val eventMarkers = markers(name, fields :+ ("exception_type" -> exception.getClass.getName))
+
+    eventLogger.info(eventMarkers, exception.getMessage, exception)
+  }
+
+  def event(e: Event): Unit = event(e.eventName, e.eventFields: _*)
+
+  private def markers(name: String, fields: Seq[(String, Any)]): LogstashMarker =
+    appendEntries(Map(fields: _*).updated("@name", name).asJava)
+}

--- a/conf/logger-config.xml
+++ b/conf/logger-config.xml
@@ -1,15 +1,14 @@
 <configuration>
 
   <appender name="logs-stdout" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-    </encoder>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
   </appender>
 
   <appender name="async-logs-stdout" class="ch.qos.logback.classic.AsyncAppender">
     <queueSize>100000</queueSize>
     <appender-ref ref="logs-stdout" />
   </appender>
-  
+
   <logger name="com.zaxxer.hikari.pool.HikariPool" level="warn" additivity="false">
     <appender-ref ref="async-logs-stdout" />
   </logger>


### PR DESCRIPTION
- Introducing Event trait and EventPublishing convenience trait.
- Event publishing supports only primitive fields. Serialization of complex types
  to json is not supported.
- Whitespace change in logger config.